### PR TITLE
Correct LICENSE file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Tests various hyperparameter combinations for both the generalized and standard 
 To delve into the specifics, review the test suite source code.
 
 # License
-This project is licensed under the MIT License. See the LICENSE.md file for details.
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.
 
 
 


### PR DESCRIPTION
The license file is `LICENSE` (no suffix) not `LICENSE.md`.  Also added a hyperlink.